### PR TITLE
Typo in some examples AND broken link in InterpolateRandomNumbers…

### DIFF
--- a/AdvancedNoise 0.9.0/Examples/InterpolateRandomNumbers.mo
+++ b/AdvancedNoise 0.9.0/Examples/InterpolateRandomNumbers.mo
@@ -32,7 +32,7 @@ equation
                                       Documentation(info="<html>
 <p>
 This example demonstrates how to use the interpolators 
-of package <a href=\"Modelica_Noise.Math.Random.Interpolators\">Math.Random.Interpolators</a> in a Modelica model.
+of package <a href=\"AdvancedNoise.Interpolators\">Interpolators</a> in a Modelica model.
 The example uses the <a href=\"Modelica_Noise.Math.Random.Utilities.impureRandom\">impure random function</a> to generate a series of random numbers.
 These are then interpolated piece-wise constantly, linearly and using the smooth interpolation of truncated ideal low-pass.
 Simulations results are shown in the figure below:

--- a/AdvancedNoise 0.9.0/Examples/SignalBasedCorrelations.mo
+++ b/AdvancedNoise 0.9.0/Examples/SignalBasedCorrelations.mo
@@ -53,8 +53,8 @@ equation
 </td></tr></table>
 </p>
 </html>", info="<html>
-<p>This example demonstrates the auto and cross correlation using different seeds.</p>
+<p>This example demonstrates the autocorrelation and cross correlation of two signal based noises using different seeds.</p>
 <p><img src=\"modelica://AdvancedNoise/Resources/Images/Examples/SignalBasedCorrelations.png\"/></p>
-<p>Both p-values for corss- and autocorrelation are high. This means, we can assume uncorrelated signals; between two different seeds as well as within a single noise signal.</p>
+<p>p-values for both cross correlation and autocorrelation are high. This means, we can assume uncorrelated signals &ndash; between two different seeds as well as within a single noise signal.</p>
 </html>"));
 end SignalBasedCorrelations;

--- a/AdvancedNoise 0.9.0/Examples/TimeBasedCorrelations.mo
+++ b/AdvancedNoise 0.9.0/Examples/TimeBasedCorrelations.mo
@@ -42,9 +42,9 @@ equation
 </td></tr></table>
 </p>
 </html>", info="<html>
-<p>This example demonstrates the auto and cross correlation using different seeds.</p>
+<p>This example demonstrates the autocorrelation and cross correlation of two time based noises using different seeds.</p>
 <p><img src=\"modelica://AdvancedNoise/Resources/Images/Examples/TimeBasedCorrelations.png\"/></p>
-<p>Both p-values for corss- and autocorrelation are high. This means, we can assume uncorrelated signals; between two different seeds as well as within a single noise signal.</p>
+<p>p-values for both cross correlation and autocorrelation are high. This means, we can assume uncorrelated signals &ndash; between two different seeds as well as within a single noise signal.</p>
 </html>"),
     experiment(StopTime=100));
 end TimeBasedCorrelations;


### PR DESCRIPTION
Typo in some examples AND broken link in Examples.InterpolateRandomNumbers: used Modelica_Noise.Math.Random.Interpolators instead of AdvancedNoise.Interpolators