### PR TITLE
Migrate Library to Modelica Standard Library 4.0.0

### DIFF
--- a/AdvancedNoise/Examples/InterpolateRandomNumbers.mo
+++ b/AdvancedNoise/Examples/InterpolateRandomNumbers.mo
@@ -3,7 +3,7 @@ model InterpolateRandomNumbers
   "Interpolate random numbers with the various interpolators"
   extends Modelica.Icons.Example;
 
-  parameter Modelica.SIunits.Time samplePeriod = 1.0
+  parameter Modelica.Units.SI.Time samplePeriod = 1.0
     "Sample period for the generation of random numbers";
   parameter Integer seed = 614657 "Seed to initialize random number generator";
 

--- a/AdvancedNoise/Examples/RailIrregularities/Comparisons/FilterAndConvolution.mo
+++ b/AdvancedNoise/Examples/RailIrregularities/Comparisons/FilterAndConvolution.mo
@@ -11,7 +11,7 @@ model FilterAndConvolution
   parameter Boolean doFilter =  true "Calculate state space phase filter?";
   parameter Boolean doTime =    false "Calculate time-based noise?";
 
-  parameter Modelica.SIunits.Duration samplePeriod = 0.2 "Common sample period";
+  parameter Modelica.Units.SI.Duration samplePeriod = 0.2 "Common sample period";
 
   inner Modelica.Blocks.Noise.GlobalSeed globalSeed(useAutomaticSeed=false)
                annotation (Placement(transformation(extent={{60,60},{80,80}})));

--- a/AdvancedNoise/Examples/SignalBasedNoise.mo
+++ b/AdvancedNoise/Examples/SignalBasedNoise.mo
@@ -1,7 +1,7 @@
 within AdvancedNoise.Examples;
 model SignalBasedNoise "Demonstrates the a simple case of signal based noise"
   extends Modelica.Icons.Example;
-  parameter Modelica.SIunits.Radius r = 1 "Radius of circle";
+  parameter Modelica.Units.SI.Radius r = 1 "Radius of circle";
   constant Real pi = Modelica.Constants.pi "Constant pi";
   inner Modelica.Blocks.Noise.GlobalSeed globalSeed
     annotation (Placement(transformation(extent={{-20,40},{0,60}})));

--- a/AdvancedNoise/Examples/TimeBasedNoise.mo
+++ b/AdvancedNoise/Examples/TimeBasedNoise.mo
@@ -2,7 +2,7 @@ within AdvancedNoise.Examples;
 model TimeBasedNoise "Demonstrates the a simple case of a timel based noise"
   extends Modelica.Icons.Example;
 
-  parameter Modelica.SIunits.Radius r = 1 "Radius of circle";
+  parameter Modelica.Units.SI.Radius r = 1 "Radius of circle";
   constant Real pi = Modelica.Constants.pi "Constant pi";
 
   inner Modelica.Blocks.Noise.GlobalSeed globalSeed

--- a/AdvancedNoise/Generators/Utilities/Interfaces/PartialGenerator/package.mo
+++ b/AdvancedNoise/Generators/Utilities/Interfaces/PartialGenerator/package.mo
@@ -46,6 +46,7 @@ initialState(..) function of a random number generator package.
 </html>"));
   end initialState;
 
+
   replaceable partial function random
   "Return a random number with a uniform distribution in the range 0.0 < result <= 1.0"
     extends Modelica.Icons.Function;
@@ -86,6 +87,7 @@ random(..) function of a random number generator package.
 </table>
 </html>"));
   end random;
+
 
 annotation (Documentation(info="<html>
 <p>

--- a/AdvancedNoise/Generators/Utilities/Interfaces/PartialGenerator/package.mo
+++ b/AdvancedNoise/Generators/Utilities/Interfaces/PartialGenerator/package.mo
@@ -46,7 +46,6 @@ initialState(..) function of a random number generator package.
 </html>"));
   end initialState;
 
-
   replaceable partial function random
   "Return a random number with a uniform distribution in the range 0.0 < result <= 1.0"
     extends Modelica.Icons.Function;
@@ -87,7 +86,6 @@ random(..) function of a random number generator package.
 </table>
 </html>"));
   end random;
-
 
 annotation (Documentation(info="<html>
 <p>

--- a/AdvancedNoise/Interpolators/FirstOrder/package.mo
+++ b/AdvancedNoise/Interpolators/FirstOrder/package.mo
@@ -7,7 +7,7 @@ package FirstOrder "A linear first order filter (k / (Ts + 1))"
                                                              suggestedSamplePeriod=0.1);
 
   constant Real k=1 "Gain";
-  constant Modelica.SIunits.Period T=0.01 "Time Constant";
+  constant Modelica.Units.SI.Period T=0.01 "Time Constant";
 
 
   redeclare function extends kernel

--- a/AdvancedNoise/Interpolators/SmoothIdealLowPass/der_kernel_offset.mo
+++ b/AdvancedNoise/Interpolators/SmoothIdealLowPass/der_kernel_offset.mo
@@ -2,7 +2,7 @@ within AdvancedNoise.Interpolators.SmoothIdealLowPass;
 function der_kernel_offset
   extends Modelica.Icons.Function;
   input Real t "The (scaled) time for sampling period=1";
-  input Modelica.SIunits.Frequency f=1/2 "The cut-off frequency of the filter";
+  input Modelica.Units.SI.Frequency f=1/2 "The cut-off frequency of the filter";
   output Real h "The impulse response of the convolution filter";
 protected
   function d = der(kernel, t);

--- a/AdvancedNoise/Interpolators/SmoothIdealLowPass/kernel.mo
+++ b/AdvancedNoise/Interpolators/SmoothIdealLowPass/kernel.mo
@@ -4,7 +4,7 @@ function kernel "Kernel for ideal low pass (sinc-function)"
   import Modelica.Math.Special.sinc;
   import Modelica.Constants.pi;
   input Real t "The (scaled) time for sampling period=1";
-  input Modelica.SIunits.Frequency f=1/2 "The cut-off frequency of the filter";
+  input Modelica.Units.SI.Frequency f=1/2 "The cut-off frequency of the filter";
   output Real h "The impulse response of the convolution filter";
 algorithm
   h := 2*f*sinc(2*pi*f*t);

--- a/AdvancedNoise/Sources/TimeBasedNoise.mo
+++ b/AdvancedNoise/Sources/TimeBasedNoise.mo
@@ -8,7 +8,7 @@ block TimeBasedNoise
   extends Modelica.Blocks.Interfaces.SO;
 
   // Main dialog menu
-  parameter Modelica.SIunits.Time samplePeriod(start=0.01)
+  parameter Modelica.Units.SI.Time samplePeriod(start=0.01)
     "Period for sampling the raw random numbers"
     annotation(Dialog(enable=enableNoise));
 
@@ -130,7 +130,7 @@ initial equation
   localSeed = if useAutomaticLocalSeed then impureRandomInteger(globalSeed.id_impure) else fixedLocalSeed;
 
 public
-  parameter Modelica.SIunits.Time startTime = 0.0
+  parameter Modelica.Units.SI.Time startTime = 0.0
     "Start time for sampling the raw random numbers"
     annotation(Dialog(tab="Advanced", group="Initialization",enable=enableNoise));
 

--- a/AdvancedNoise/Statistics/AutoCorrelationTest.mo
+++ b/AdvancedNoise/Statistics/AutoCorrelationTest.mo
@@ -3,7 +3,7 @@ block AutoCorrelationTest
   "Tests the null hypothesis that a signal is uncorrelated with a given offset"
   extends Modelica.Blocks.Interfaces.SISO;
 
-  parameter Modelica.SIunits.Time delta_t(min=0) = 0.1
+  parameter Modelica.Units.SI.Time delta_t(min=0) = 0.1
     "Time delay for auto-correlation of signal";
 
   CorrelationTest correlationTest(correlation(delta_t=delta_t))

--- a/AdvancedNoise/Statistics/Correlation.mo
+++ b/AdvancedNoise/Statistics/Correlation.mo
@@ -4,18 +4,18 @@ block Correlation "Calculates the correlation of two signals"
 
 // Parameters
 public
-  parameter Modelica.SIunits.Time delta_t(min=0) = 0.0
+  parameter Modelica.Units.SI.Time delta_t(min=0) = 0.0
     "Time delay for auto-correlation of signal";
 
 // The start time of the simulation
 protected
-  parameter Modelica.SIunits.Time t_0(fixed=false) "Start time of the simulation";
+  parameter Modelica.Units.SI.Time t_0(fixed=false) "Start time of the simulation";
 initial equation
   t_0 = time;
 
 // The local integration time
 public
-  Modelica.SIunits.Time t = max(0, time - delta_t - t_0)
+  Modelica.Units.SI.Time t = max(0, time - delta_t - t_0)
     "The local integration time (starts only after an offset of delta_t";
 
 // The actual signals to correlate

--- a/AdvancedNoise/Statistics/CorrelationTest.mo
+++ b/AdvancedNoise/Statistics/CorrelationTest.mo
@@ -5,9 +5,9 @@ block CorrelationTest
 
 // The start time of the simulation
 protected
-  parameter Modelica.SIunits.Time t_0(fixed=false) "Start time of the simulation";
+  parameter Modelica.Units.SI.Time t_0(fixed=false) "Start time of the simulation";
 public
-  parameter Modelica.SIunits.Time t_eps = 0.001
+  parameter Modelica.Units.SI.Time t_eps = 0.001
     "Start evaluating shortly after simulation start";
 initial equation
   t_0 = time;

--- a/AdvancedNoise/Tests/Derivatives.mo
+++ b/AdvancedNoise/Tests/Derivatives.mo
@@ -105,7 +105,7 @@ model Derivatives "Tests derivatives of the random numbers"
     redeclare function distribution =
         Modelica.Math.Distributions.Uniform.quantile (y_min=-1, y_max=3))
     annotation (Placement(transformation(extent={{0,-100},{20,-80}})));
-  Modelica.Blocks.Sources.Sine sine(freqHz=0.3)
+  Modelica.Blocks.Sources.Sine sine(f=0.3)
     annotation (Placement(transformation(extent={{-96,-20},{-76,0}})));
   Modelica.Blocks.Continuous.Der der1
     annotation (Placement(transformation(extent={{-32,16},{-24,24}})));

--- a/AdvancedNoise/package.mo
+++ b/AdvancedNoise/package.mo
@@ -8,7 +8,7 @@ package AdvancedNoise "A library with additional noise modules compatible to the
     versionDate =  "2019-05-31",
     versionBuild = 1,
     dateModified = "2019-05-31 12:00:00Z",
-    uses(Modelica(version="3.2.3")),
+    uses(Modelica(version="4.0.0")),
     Icon(graphics={Line(
       points={{-84,0},{-54,0},{-54,40},{-24,40},{-24,-70},{6,-70},{6,80},{36,80},
             {36,-20},{66,-20},{66,60}})}),


### PR DESCRIPTION
This means to change "Modelica.SIunits" to "Modelica.Units.SI" (solved by importing the package) and "freqHz" to "f" in the Sine and Cosine Source Blocks.